### PR TITLE
Document integration tests and register pytest marker

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -41,6 +41,18 @@ If you encounter "command not found" errors, ensure your virtual environment is 
 python3 -m pytest
 ```
 
+### Integration tests
+
+The suite includes a small number of `@pytest.mark.integration` tests that hit a
+real Dolibarr instance. They are skipped by default unless valid credentials are
+present. To run them:
+
+```bash
+export DOLIBARR_URL="https://your-dolibarr.example.com/api/index.php"
+export DOLIBARR_API_KEY="your-api-key"
+pytest -m integration
+```
+
 ## Formatting and linting
 
 The project intentionally avoids heavy linting dependencies. Follow the coding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short --cov=src/dolibarr_mcp"
+markers = [
+    "integration: tests that require a real Dolibarr instance and valid credentials",
+]
 
 [tool.coverage.run]
 source = ["src/dolibarr_mcp"]


### PR DESCRIPTION
## Summary
- register the integration test marker in pytest config to silence warnings
- document how to run the optional Dolibarr integration tests with real credentials

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955258bef74832291123e797bb59292)