### PR TITLE
Make Docker Compose container and network names configurable via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ MCP_TRANSPORT=http
 MCP_HTTP_HOST=0.0.0.0
 MCP_HTTP_PORT=8080
 MCP_HOST_PORT=18004
+
+# Docker Compose naming
+MCP_CONTAINER_NAME=dolibarr-mcp-server
+MCP_NETWORK_NAME=dolibarr-mcp-net

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ overwritten by `git pull` on your server.
 | `MCP_HTTP_HOST` | Host/interface to bind when using HTTP transport (default `0.0.0.0`). |
 | `MCP_HTTP_PORT` | Port to bind when using HTTP transport (default `8080`). |
 | `MCP_HOST_PORT` | Optional host port to publish in Docker Compose (default `18004`). |
+| `MCP_CONTAINER_NAME` | Optional Docker Compose container name (default `dolibarr-mcp-server`). |
+| `MCP_NETWORK_NAME` | Optional Docker Compose network name (default `dolibarr-mcp-net`). |
 
 Example `.env`:
 
@@ -107,6 +109,8 @@ Example `.env`:
 DOLIBARR_URL=https://your-dolibarr.example.com/api/index.php
 DOLIBARR_API_KEY=YOUR_API_KEY
 LOG_LEVEL=INFO
+MCP_CONTAINER_NAME=dolibarr-mcp-server
+MCP_NETWORK_NAME=dolibarr-mcp-net
 ```
 
 ### Claude Desktop configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     image: dolibarr-mcp:latest
-    container_name: dolibarr-mcp-server
+    container_name: ${MCP_CONTAINER_NAME:-dolibarr-mcp-server}
     restart: unless-stopped
     environment:
       # Dolibarr API Configuration
@@ -74,7 +74,7 @@ services:
 networks:
   dolibarr-mcp-network:
     driver: bridge
-    name: dolibarr-mcp-net
+    name: ${MCP_NETWORK_NAME:-dolibarr-mcp-net}
 
 # To run the main server:
 # docker compose up -d


### PR DESCRIPTION
### Motivation
- Avoid container name conflicts and make deployments more flexible by allowing the Docker Compose container and network names to be overridden from the environment.
- Preserve the current names as the defaults while exposing `MCP_CONTAINER_NAME` and `MCP_NETWORK_NAME` so operators can change them in `.env` when needed.

### Description
- `docker-compose.yml` now uses `container_name: ${MCP_CONTAINER_NAME:-dolibarr-mcp-server}` to allow overriding the main container name via `MCP_CONTAINER_NAME`.
- `docker-compose.yml` now uses `name: ${MCP_NETWORK_NAME:-dolibarr-mcp-net}` for the compose network to allow overriding via `MCP_NETWORK_NAME`.
- `.env.example` was updated to include `MCP_CONTAINER_NAME` and `MCP_NETWORK_NAME` with the current defaults shown.
- `README.md` was updated to document the new environment variables and include them in the sample `.env` block.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836a0df72483228fd10dfdbad819b7)