### PR TITLE
Add MCP_NETWORK_EXTERNAL and document external Docker network option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ MCP_HOST_PORT=18004
 # Docker Compose naming
 MCP_CONTAINER_NAME=dolibarr-mcp-server
 MCP_NETWORK_NAME=dolibarr-mcp-net
+MCP_NETWORK_EXTERNAL=false

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ overwritten by `git pull` on your server.
 | `MCP_HOST_PORT` | Optional host port to publish in Docker Compose (default `18004`). |
 | `MCP_CONTAINER_NAME` | Optional Docker Compose container name (default `dolibarr-mcp-server`). |
 | `MCP_NETWORK_NAME` | Optional Docker Compose network name (default `dolibarr-mcp-net`). |
+| `MCP_NETWORK_EXTERNAL` | Set to `true` to reuse an existing Docker network (default `false`). |
 
 Example `.env`:
 
@@ -111,6 +112,7 @@ DOLIBARR_API_KEY=YOUR_API_KEY
 LOG_LEVEL=INFO
 MCP_CONTAINER_NAME=dolibarr-mcp-server
 MCP_NETWORK_NAME=dolibarr-mcp-net
+MCP_NETWORK_EXTERNAL=false
 ```
 
 ### Claude Desktop configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ networks:
   dolibarr-mcp-network:
     driver: bridge
     name: ${MCP_NETWORK_NAME:-dolibarr-mcp-net}
+    external: ${MCP_NETWORK_EXTERNAL:-false}
 
 # To run the main server:
 # docker compose up -d


### PR DESCRIPTION
### Motivation
- Allow Docker Compose to reuse an existing Docker network to avoid warnings about pre-existing networks and support environments where the network is managed externally.

### Description
- Add `external: ${MCP_NETWORK_EXTERNAL:-false}` to the `dolibarr-mcp-network` definition in `docker-compose.yml` to enable reusing an external network.
- Document the new `MCP_NETWORK_EXTERNAL` variable in `README.md` and include it in the example `.env` block.
- Add `MCP_NETWORK_EXTERNAL=false` to `.env.example` so the example environment file reflects the new option.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836c2bf76c832282d5deccfe537fdd)