### PR TITLE
feat(tickets): add ticket management support (closes #27)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md
+
+Agent instructions for productive work in this repository.
+
+## Project Snapshot
+
+- Python MCP server for Dolibarr ERP/CRM.
+- Main flow: MCP server tools -> `DolibarrClient` -> Dolibarr REST API.
+- Core paths:
+  - `src/dolibarr_mcp/dolibarr_mcp_server.py` (tool schemas + dispatch)
+  - `src/dolibarr_mcp/dolibarr_client.py` (HTTP client, validation, retries)
+  - `src/dolibarr_mcp/config.py` (env-driven settings)
+
+## Fast Commands
+
+- Setup:
+  - `python3 -m venv venv_dolibarr`
+  - `source venv_dolibarr/bin/activate`
+  - `pip install -e .`
+  - `pip install -e '.[dev]'`
+- Run MCP server (STDIO):
+  - `python -m dolibarr_mcp.dolibarr_mcp_server`
+- Run MCP server (HTTP):
+  - `MCP_TRANSPORT=http MCP_HTTP_PORT=8080 python -m dolibarr_mcp.dolibarr_mcp_server`
+- Tests:
+  - `pytest`
+  - `pytest -m "not integration"`
+  - `pytest -m integration` (requires valid Dolibarr credentials)
+  - `pytest --cov=src/dolibarr_mcp --cov-report=term-missing`
+
+## Non-Negotiable Conventions
+
+- Keep stdout clean in server mode; logging must not break MCP protocol.
+- Keep changes minimal and scoped; do not refactor unrelated areas.
+- Follow current style; repository intentionally has no heavy lint pipeline.
+- Never log secrets (API keys, tokens).
+- Use existing docs as source of truth; link rather than duplicating details.
+
+## Common Change Playbooks
+
+### Add or modify an MCP tool
+
+1. Update tool definition in `handle_list_tools()` (`src/dolibarr_mcp/dolibarr_mcp_server.py`).
+2. Update tool dispatch in `handle_call_tool()` (`src/dolibarr_mcp/dolibarr_mcp_server.py`).
+3. Add or adapt client method in `src/dolibarr_mcp/dolibarr_client.py`.
+4. Add/adjust tests in `tests/` (unit first, integration only where needed).
+5. Run `pytest -m "not integration"` before finishing.
+
+### Add API payload fields
+
+- Validate through client-side validation helpers before request dispatch.
+- Preserve existing alias/required-field patterns in `dolibarr_client.py`.
+- Keep structured error format stable (`validation_error` / `internal_error`).
+
+## Testing Guidance
+
+- Default: fast unit test cycle via `pytest -m "not integration"`.
+- Integration tests are credential-dependent and may be skipped in CI/local runs.
+- For tool-level behavior, prefer mocking `DolibarrClient` in server tests.
+
+## Pitfalls
+
+- SQL filter terms must escape single quotes before building `sqlfilters`.
+- Ensure environment uses API URL form expected by docs (`.../api/index.php`).
+- HTTP transport requires `MCP_TRANSPORT=http`; default is STDIO.
+
+## Documentation Map (link, do not duplicate)
+
+- Overview and usage: [README.md](README.md)
+- Docs index: [docs/README.md](docs/README.md)
+- Configuration details: [docs/configuration.md](docs/configuration.md)
+- API/tool behavior: [docs/api-reference.md](docs/api-reference.md)
+- Development and debugging: [docs/development.md](docs/development.md)
+- Quick local startup: [docs/quickstart.md](docs/quickstart.md)
+
+## Optional Improvement Areas
+
+- Split large server dispatch into smaller modules when doing major feature work.
+- Add focused tests whenever touching invoice/project/search tool behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Dolibarr MCP Server are documented here. The project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and adopts the
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
+## [1.2.0]
+
+### Added
+- Ticket management tools: `get_tickets`, `get_ticket_by_ref`, `search_tickets`, `create_ticket`, `add_ticket_message`, and `update_ticket`. Tickets are addressed by their business reference (`ref`, e.g. `TI1046`) rather than the internal row id; `add_ticket_message` and `update_ticket` resolve a `ref` to the required `track_id`/numeric id automatically.
+
+### Changed
+- Unified the project version to `1.2.0` across `pyproject.toml`, package `__version__`, the CLI, the MCP server handshake, and `docker-compose.yml`.
+
 ### Added
 - Restored README.md and CHANGELOG.md after merge conflicts while preserving the streamlined structure shared with `prestashop-mcp`.
 - Documented platform-specific setup covering Linux/macOS shells, Windows Visual Studio `vsenv`, and the Docker workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Python MCP (Model Context Protocol) server exposing Dolibarr ERP/CRM REST API
+operations as MCP tools. Request flow: **MCP tool call → `dolibarr_mcp_server.py`
+dispatch → `DolibarrClient` method → Dolibarr REST API (`/api/index.php`)**.
+
+A sibling project, [`prestashop-mcp`](https://github.com/latinogino/prestashop-mcp),
+intentionally shares this repo's structure and tooling. Keep changes aligned with
+that layout when restructuring.
+
+## Commands
+
+```bash
+# Setup (src/ layout, editable install)
+python3 -m venv venv_dolibarr && source venv_dolibarr/bin/activate
+pip install -e '.[dev]'
+
+# Run server (STDIO is default transport)
+python -m dolibarr_mcp.dolibarr_mcp_server
+MCP_TRANSPORT=http MCP_HTTP_PORT=8080 python -m dolibarr_mcp.dolibarr_mcp_server
+
+# Verify Dolibarr credentials without an MCP host
+python -m dolibarr_mcp.test_connection            # uses env vars
+python -m dolibarr_mcp.test_connection --url https://.../api/index.php --api-key KEY
+
+# Tests
+pytest                              # all (pytest.ini_options forces --cov)
+pytest -m "not integration"         # fast unit cycle — default while developing
+pytest -m integration               # requires a real Dolibarr instance + credentials
+pytest tests/test_search_tools.py::TestName::test_name   # single test
+```
+
+There is no lint pipeline. Match existing style; do not introduce one unprompted.
+
+## Architecture
+
+Two files hold almost all the logic:
+
+- **`src/dolibarr_mcp/dolibarr_mcp_server.py`** (~1600 lines) — every MCP tool.
+  Tool *schemas* live in `handle_list_tools()`; tool *dispatch* lives in
+  `handle_call_tool()`. Adding/changing a tool means editing **both**. The tail
+  of the file (`_run_stdio_server`, `_build_http_app`, `_run_http_server`, `main`)
+  wires up STDIO vs. Starlette/Streamable-HTTP transports.
+- **`src/dolibarr_mcp/dolibarr_client.py`** (~870 lines) — async aiohttp client.
+  All HTTP goes through `_make_request()`, which handles retries (transient
+  errors, `MAX_RETRIES`/`RETRY_BACKOFF_SECONDS`), payload validation
+  (`_validate_payload`, `_apply_aliases`), and **structured error envelopes**
+  (`_build_validation_error` → `validation_error`, `_build_internal_error` →
+  `internal_error`). Keep that error shape stable — tests and callers depend on it.
+- **`src/dolibarr_mcp/config.py`** — pydantic-settings `Config`. Reads env / `.env`.
+  `DOLIBARR_URL`, `DOLIBARR_BASE_URL`, and `DOLIBARR_SHOP_URL` are all accepted
+  aliases for the base URL, and the validator normalizes any of them to end in
+  `/api/index.php`. Missing config warns to **stderr** and falls back to
+  placeholders rather than crashing (so the server still starts).
+
+## Conventions specific to this codebase
+
+- **Specialized search tools, not generic getters.** Instead of one `get_products`
+  that dumps everything, the server exposes `search_products_by_ref`,
+  `search_products_by_label`, `resolve_product_ref`, `search_customers`,
+  `search_projects`. These push filtering server-side via Dolibarr's `sqlfilters`
+  to avoid loading thousands of records into the model's context. When adding a
+  list-style tool, prefer this filtered pattern over a bulk fetch.
+- **`sqlfilters` need escaping.** Use `_escape_sqlfilter()` (server) before
+  interpolating user values into a `sqlfilters` string — single quotes must be
+  escaped or the filter breaks / is injectable.
+- **stdout must stay clean in STDIO mode.** All logging and diagnostics go to
+  **stderr**; anything on stdout corrupts the MCP protocol stream.
+- **Invoice lines come from a separate endpoint.** Invoice detail fetches the
+  lines via a distinct API call (see the most recent commit) — don't assume the
+  invoice object already contains them.
+- **Reference autogen is opt-in.** `ALLOW_REF_AUTOGEN` / `REF_AUTOGEN_PREFIX`
+  control whether missing `ref` fields are auto-generated.
+
+## Adding or modifying a tool (checklist)
+
+1. Update the schema in `handle_list_tools()`.
+2. Update the `elif name == ...` branch in `handle_call_tool()`.
+3. Add/adapt the method in `dolibarr_client.py`, reusing `_validate_payload`,
+   the alias helpers, and the structured-error builders.
+4. Add unit tests in `tests/` (mock `DolibarrClient` for server-level tests).
+5. Run `pytest -m "not integration"` before finishing.
+
+## Further docs
+
+`AGENTS.md` covers playbooks and pitfalls. Deep dives live in `docs/`:
+[configuration.md](docs/configuration.md), [api-reference.md](docs/api-reference.md),
+[development.md](docs/development.md), [quickstart.md](docs/quickstart.md). Link to
+these rather than duplicating their content here.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       MCP_HTTP_PORT: ${MCP_HTTP_PORT:-8080}
       MCP_HTTP_HOST: ${MCP_HTTP_HOST:-0.0.0.0}
       MCP_SERVER_NAME: dolibarr-mcp
-      MCP_SERVER_VERSION: 1.0.0
+      MCP_SERVER_VERSION: 1.2.0
 
     # Expose port for HTTP MCP clients
     ports:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -29,6 +29,7 @@ implements for PrestaShop.
 | Orders          | `/orders`                   | Order CRUD operations                   |
 | Projects        | `/projects`                 | Project CRUD operations & Search        |
 | Contacts        | `/contacts`                 | Contact CRUD operations                 |
+| Tickets         | `/tickets`                  | `get_tickets`, `get_ticket_by_ref`, `search_tickets`, `create_ticket`, `add_ticket_message`, `update_ticket` |
 | Raw passthrough | Any relative path           | `dolibarr_raw_api` tool for quick tests |
 
 Every endpoint supports create, read, update and delete operations unless noted
@@ -158,3 +159,27 @@ curl -X POST "https://dolibarr.example/api/index.php/projects" \
 If server-side reference auto-generation is enabled, omitting `ref` results in a
 predictable `AUTO_<timestamp>` reference. Otherwise, the wrapper will raise a
 client-side validation error before sending the request.
+
+## Tickets
+
+The ticket tools work with the business reference (the `ref` column, e.g.
+`TI1046`) rather than the internal numeric row id. Note these endpoint
+specifics:
+
+- **List / search** – `GET /tickets`. The Dolibarr `status` query parameter is
+  unreliable for tickets, so `get_tickets` filters via `sqlfilters` on
+  `t.fk_statut`. Without a status filter it returns open tickets only
+  (excludes `8`=closed and `9`=cancelled). Status codes: `0`=unread, `1`=read,
+  `3`=assigned, `4`=in progress, `5`=waiting for customer, `7`=waiting for
+  helpdesk, `8`=closed, `9`=cancelled.
+- **Read by reference** – `get_ticket_by_ref` calls `GET /tickets/ref/{ref}`.
+  The response includes the `messages` array and the `track_id`.
+- **Create** – `create_ticket` calls `POST /tickets` and requires `subject` and
+  `message`. `socid` links a thirdparty (the `fk_soc` alias is accepted).
+- **Add message** – `add_ticket_message` calls `POST /tickets/messages`. The
+  Dolibarr endpoint requires `track_id` (not the ref). For convenience the tool
+  accepts either `track_id` or `ref`; when only `ref` is given it is resolved to
+  the `track_id` via `GET /tickets/ref/{ref}` first.
+- **Update** – `update_ticket` calls `PUT /tickets/{id}`. This endpoint only
+  accepts the numeric id, so when only a `ref` is supplied the tool resolves it
+  to the internal id first.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dolibarr-mcp"
-version = "1.1.0"
+version = "1.2.0"
 description = "Professional Model Context Protocol server for complete Dolibarr ERP/CRM management"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """Dolibarr MCP Package."""
 
-__version__ = "1.0.0"
+__version__ = "1.2.0"

--- a/src/dolibarr_mcp/__init__.py
+++ b/src/dolibarr_mcp/__init__.py
@@ -4,7 +4,7 @@ Dolibarr MCP Server Package
 Professional Model Context Protocol server for complete Dolibarr ERP/CRM management.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __author__ = "Dolibarr MCP Team"
 
 from .dolibarr_client import DolibarrClient

--- a/src/dolibarr_mcp/cli.py
+++ b/src/dolibarr_mcp/cli.py
@@ -12,7 +12,7 @@ from .testing import test_connection as run_test_connection
 
 
 @click.group()
-@click.version_option(version="1.1.0", prog_name="dolibarr-mcp")
+@click.version_option(version="1.2.0", prog_name="dolibarr-mcp")
 def cli():
     """Dolibarr MCP Server - Professional ERP integration via Model Context Protocol."""
     pass

--- a/src/dolibarr_mcp/dolibarr_client.py
+++ b/src/dolibarr_mcp/dolibarr_client.py
@@ -866,7 +866,9 @@ class DolibarrClient:
         and cancelled). The Dolibarr ``status`` query parameter is unreliable for
         tickets, so filtering is done via ``sqlfilters`` on ``t.fk_statut``.
         """
-        params: Dict[str, Any] = {"limit": limit, "page": page}
+        params: Dict[str, Any] = {"limit": limit}
+        if page and page > 1:
+            params["page"] = page
         if status is not None:
             params["sqlfilters"] = f"(t.fk_statut:=:{int(status)})"
         else:

--- a/src/dolibarr_mcp/dolibarr_client.py
+++ b/src/dolibarr_mcp/dolibarr_client.py
@@ -856,6 +856,136 @@ class DolibarrClient:
         return await self.request("DELETE", f"projects/{project_id}")
 
     # ============================================================================
+    # TICKET MANAGEMENT
+    # ============================================================================
+
+    async def get_tickets(self, limit: int = 100, page: int = 1, status: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Get list of tickets.
+
+        When ``status`` is None the open tickets are returned (excluding closed
+        and cancelled). The Dolibarr ``status`` query parameter is unreliable for
+        tickets, so filtering is done via ``sqlfilters`` on ``t.fk_statut``.
+        """
+        params: Dict[str, Any] = {"limit": limit, "page": page}
+        if status is not None:
+            params["sqlfilters"] = f"(t.fk_statut:=:{int(status)})"
+        else:
+            params["sqlfilters"] = "(t.fk_statut:!=:8) and (t.fk_statut:!=:9)"
+        result = await self.request("GET", "tickets", params=params)
+        return result if isinstance(result, list) else []
+
+    async def get_ticket_by_ref(self, ref: str) -> Dict[str, Any]:
+        """Get a specific ticket by its business reference (e.g. ``TI1046``).
+
+        The response includes the ``messages`` array and the ``track_id`` needed
+        to post new messages.
+        """
+        return await self.request("GET", f"tickets/ref/{ref}")
+
+    async def search_tickets(self, sqlfilters: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """Search tickets using SQL filters."""
+        params = {"limit": limit, "sqlfilters": sqlfilters}
+        result = await self.request("GET", "tickets", params=params)
+        return result if isinstance(result, list) else []
+
+    async def create_ticket(self, data: Optional[Dict[str, Any]] = None, **kwargs) -> Dict[str, Any]:
+        """Create a new ticket.
+
+        Dolibarr requires ``subject`` and ``message``. ``socid`` links the ticket
+        to a thirdparty and is accepted via the ``fk_soc`` alias as well.
+        """
+        payload = self._merge_payload(data, **kwargs)
+        payload = self._validate_payload(
+            endpoint="tickets",
+            payload=payload,
+            required_fields=["subject", "message"],
+            aliases={"socid": ["fk_soc"]},
+            non_empty_fields=["subject", "message"],
+        )
+        result = await self.request("POST", "tickets", data=payload)
+        return self._extract_identifier(result)
+
+    async def _resolve_ticket_track_id(self, ref: str) -> str:
+        """Resolve a ticket reference to its ``track_id``."""
+        ticket = await self.get_ticket_by_ref(ref)
+        track_id = ticket.get("track_id") if isinstance(ticket, dict) else None
+        if not track_id:
+            error_data = self._build_validation_error(
+                endpoint="tickets/messages",
+                invalid_fields=[{"field": "ref", "message": f"no track_id found for ticket ref '{ref}'"}],
+                message=f"Could not resolve track_id for ticket ref '{ref}'",
+            )
+            raise DolibarrValidationError(
+                message=error_data["message"],
+                status_code=error_data["status"],
+                response_data=error_data,
+            )
+        return track_id
+
+    async def add_ticket_message(self, data: Optional[Dict[str, Any]] = None, **kwargs) -> Dict[str, Any]:
+        """Add a message to a ticket.
+
+        The Dolibarr endpoint ``POST /tickets/messages`` requires ``track_id`` and
+        ``message``. For convenience a ``ref`` may be supplied instead of
+        ``track_id``; it is resolved to the matching ``track_id`` first.
+        """
+        payload = self._merge_payload(data, **kwargs)
+        payload = self._validate_payload(
+            endpoint="tickets/messages",
+            payload=payload,
+            required_fields=["message"],
+            required_any_of=[["track_id", "ref"]],
+            non_empty_fields=["message"],
+        )
+
+        if not payload.get("track_id"):
+            payload["track_id"] = await self._resolve_ticket_track_id(payload["ref"])
+        # ``ref`` is not part of the API payload; drop it before sending.
+        payload.pop("ref", None)
+
+        return await self.request("POST", "tickets/messages", data=payload)
+
+    async def update_ticket(
+        self,
+        ticket_id: Optional[int] = None,
+        ref: Optional[str] = None,
+        data: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Update an existing ticket.
+
+        The Dolibarr ``PUT`` endpoint only accepts the numeric id. When only a
+        ``ref`` is known it is resolved to the internal id first.
+        """
+        payload = self._merge_payload(data, **kwargs)
+        if ticket_id is None:
+            if not ref:
+                error_data = self._build_validation_error(
+                    endpoint="tickets",
+                    missing_fields=["ticket_id or ref"],
+                    message="Validation failed (missing: ticket_id or ref)",
+                )
+                raise DolibarrValidationError(
+                    message=error_data["message"],
+                    status_code=error_data["status"],
+                    response_data=error_data,
+                )
+            ticket = await self.get_ticket_by_ref(ref)
+            ticket_id = ticket.get("id") if isinstance(ticket, dict) else None
+            if not ticket_id:
+                error_data = self._build_validation_error(
+                    endpoint="tickets",
+                    invalid_fields=[{"field": "ref", "message": f"no ticket found for ref '{ref}'"}],
+                    message=f"Could not resolve ticket id for ref '{ref}'",
+                )
+                raise DolibarrValidationError(
+                    message=error_data["message"],
+                    status_code=error_data["status"],
+                    response_data=error_data,
+                )
+        return await self.request("PUT", f"tickets/{ticket_id}", data=payload)
+
+    # ============================================================================
     # RAW API CALL
     # ============================================================================
     

--- a/src/dolibarr_mcp/dolibarr_mcp_server.py
+++ b/src/dolibarr_mcp/dolibarr_mcp_server.py
@@ -1101,6 +1101,190 @@ async def handle_list_tools():
             },
         ),
 
+        # Ticket Management
+        Tool(
+            name="get_tickets",
+            description=(
+                "Get a list of tickets from Dolibarr. By default only open tickets are returned "
+                "(closed and cancelled tickets are excluded). Optionally filter by a specific status. "
+                "Status codes: 0=unread, 1=read, 3=assigned, 4=in progress, 5=waiting for customer, "
+                "7=waiting for helpdesk, 8=closed, 9=cancelled. "
+                "Do not use this to look up a single ticket by reference (use get_ticket_by_ref) "
+                "or to search by subject/reference (use search_tickets)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of tickets to return (default: 100)",
+                        "default": 100,
+                    },
+                    "page": {
+                        "type": "integer",
+                        "description": "Page number for pagination (default: 1)",
+                        "default": 1,
+                    },
+                    "status": {
+                        "type": "integer",
+                        "description": (
+                            "Optional exact status filter (fk_statut). Omit to return all open "
+                            "tickets. E.g. 4=in progress, 5=waiting for customer, 8=closed."
+                        ),
+                    },
+                },
+                "additionalProperties": False,
+            },
+        ),
+        Tool(
+            name="get_ticket_by_ref",
+            description=(
+                "Get the full details of exactly one ticket by its business reference (e.g. 'TI1046'). "
+                "This is the column 'ref' in Dolibarr, NOT the internal numeric row id. "
+                "The response includes the messages array and the track_id required for add_ticket_message."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref": {
+                        "type": "string",
+                        "description": "Ticket reference, e.g. 'TI1046'.",
+                    }
+                },
+                "required": ["ref"],
+                "additionalProperties": False,
+            },
+        ),
+        Tool(
+            name="search_tickets",
+            description=(
+                "Search tickets by reference, subject or track_id. Use this when you have a partial or "
+                "full term and need to find matching tickets without loading the full ticket list."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search term matched against ticket ref, subject and track_id.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of results",
+                        "default": 20,
+                    },
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        ),
+        Tool(
+            name="create_ticket",
+            description="Create a new ticket. Requires a subject and an initial message.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "subject": {"type": "string", "description": "Ticket subject/title"},
+                    "message": {
+                        "type": "string",
+                        "description": "Initial ticket message body",
+                    },
+                    "socid": {
+                        "type": "integer",
+                        "description": "Linked thirdparty/customer ID (optional)",
+                    },
+                    "type_code": {
+                        "type": "string",
+                        "description": "Ticket type code, e.g. 'REQUEST', 'ISSUE' (optional)",
+                    },
+                    "category_code": {
+                        "type": "string",
+                        "description": "Ticket category code (optional)",
+                    },
+                    "severity_code": {
+                        "type": "string",
+                        "description": "Ticket severity code, e.g. 'NORMAL' (optional)",
+                    },
+                    "fk_user_assign": {
+                        "type": "integer",
+                        "description": "ID of the user the ticket is assigned to (optional)",
+                    },
+                },
+                "required": ["subject", "message"],
+                "additionalProperties": False,
+            },
+        ),
+        Tool(
+            name="add_ticket_message",
+            description=(
+                "Add a message to an existing ticket. Provide the ticket reference 'ref' (e.g. 'TI1046') "
+                "OR the 'track_id'. If only 'ref' is given the track_id is resolved automatically. "
+                "Prefer 'ref' unless you already know the track_id."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref": {
+                        "type": "string",
+                        "description": "Ticket reference, e.g. 'TI1046' (alternative to track_id).",
+                    },
+                    "track_id": {
+                        "type": "string",
+                        "description": "Ticket track_id (alternative to ref).",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Message body to add to the ticket",
+                    },
+                    "private": {
+                        "type": "integer",
+                        "description": "1 for an internal/private message, 0 for public (optional)",
+                    },
+                },
+                "required": ["message"],
+                "additionalProperties": False,
+            },
+        ),
+        Tool(
+            name="update_ticket",
+            description=(
+                "Update an existing ticket (e.g. change status, subject or assignment). "
+                "Provide the ticket reference 'ref' (e.g. 'TI1046') OR the numeric 'ticket_id'. "
+                "If only 'ref' is given the internal id is resolved automatically."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "ref": {
+                        "type": "string",
+                        "description": "Ticket reference, e.g. 'TI1046' (alternative to ticket_id).",
+                    },
+                    "ticket_id": {
+                        "type": "integer",
+                        "description": "Internal numeric ticket id (alternative to ref).",
+                    },
+                    "subject": {"type": "string", "description": "Updated subject"},
+                    "message": {"type": "string", "description": "Updated message"},
+                    "fk_statut": {
+                        "type": "integer",
+                        "description": (
+                            "New status. 0=unread, 1=read, 3=assigned, 4=in progress, "
+                            "5=waiting for customer, 7=waiting for helpdesk, 8=closed, 9=cancelled."
+                        ),
+                    },
+                    "fk_user_assign": {
+                        "type": "integer",
+                        "description": "ID of the user the ticket is assigned to",
+                    },
+                    "severity_code": {
+                        "type": "string",
+                        "description": "Ticket severity code, e.g. 'NORMAL'",
+                    },
+                },
+                "additionalProperties": False,
+            },
+        ),
+
         # Raw API Access
         Tool(
             name="dolibarr_raw_api",
@@ -1369,6 +1553,37 @@ async def handle_call_tool(name: str, arguments: dict):
             elif name == "delete_project":
                 result = await client.delete_project(arguments["project_id"])
 
+            # Ticket Management
+            elif name == "get_tickets":
+                result = await client.get_tickets(
+                    limit=arguments.get("limit", 100),
+                    page=arguments.get("page", 1),
+                    status=arguments.get("status"),
+                )
+
+            elif name == "get_ticket_by_ref":
+                result = await client.get_ticket_by_ref(arguments["ref"])
+
+            elif name == "search_tickets":
+                query = _escape_sqlfilter(arguments["query"])
+                limit = arguments.get("limit", 20)
+                sqlfilters = (
+                    f"((t.ref:like:'%{query}%') OR (t.subject:like:'%{query}%') "
+                    f"OR (t.track_id:like:'%{query}%'))"
+                )
+                result = await client.search_tickets(sqlfilters=sqlfilters, limit=limit)
+
+            elif name == "create_ticket":
+                result = await client.create_ticket(**arguments)
+
+            elif name == "add_ticket_message":
+                result = await client.add_ticket_message(**arguments)
+
+            elif name == "update_ticket":
+                ticket_id = arguments.pop("ticket_id", None)
+                ref = arguments.pop("ref", None)
+                result = await client.update_ticket(ticket_id=ticket_id, ref=ref, **arguments)
+
             # Raw API Access
             elif name == "dolibarr_raw_api":
                 result = await client.dolibarr_raw_api(**arguments)
@@ -1454,7 +1669,7 @@ async def _run_stdio_server(_config: Config) -> None:
             write_stream,
             InitializationOptions(
                 server_name="dolibarr-mcp",
-                server_version="1.0.1",
+                server_version="1.2.0",
                 capabilities=server.get_capabilities(
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},

--- a/tests/test_ticket_operations.py
+++ b/tests/test_ticket_operations.py
@@ -1,0 +1,197 @@
+"""
+Ticket Management Tests for Dolibarr MCP Server.
+
+These tests verify the ticket tools: listing, lookup by reference, search,
+creation, adding messages, and updates. Focus is on the ticket-specific
+behaviour (ref/track_id resolution and payload validation).
+Run with: pytest tests/test_ticket_operations.py -v
+"""
+
+import pytest
+from unittest.mock import patch, AsyncMock
+
+# Add src to path for imports
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from dolibarr_mcp import DolibarrClient, Config
+from dolibarr_mcp.dolibarr_client import DolibarrValidationError
+
+
+class TestTicketOperations:
+    """Test ticket tools on the Dolibarr client."""
+
+    @pytest.fixture
+    def config(self):
+        return Config(
+            dolibarr_url="https://test.dolibarr.com",
+            dolibarr_api_key="test_api_key",
+            log_level="INFO",
+        )
+
+    @pytest.fixture
+    def client(self, config):
+        return DolibarrClient(config)
+
+    @pytest.mark.asyncio
+    async def test_get_tickets_defaults_to_open(self, client):
+        """Without a status filter only open tickets are requested."""
+        with patch.object(client, 'request', new=AsyncMock(return_value=[])) as mock_request:
+            await client.get_tickets()
+
+            method, endpoint = mock_request.call_args[0]
+            params = mock_request.call_args[1]["params"]
+            assert method == "GET"
+            assert endpoint == "tickets"
+            assert params["sqlfilters"] == "(t.fk_statut:!=:8) and (t.fk_statut:!=:9)"
+
+    @pytest.mark.asyncio
+    async def test_get_tickets_with_status_filter(self, client):
+        """An explicit status filters on fk_statut."""
+        with patch.object(client, 'request', new=AsyncMock(return_value=[])) as mock_request:
+            await client.get_tickets(status=5)
+
+            params = mock_request.call_args[1]["params"]
+            assert params["sqlfilters"] == "(t.fk_statut:=:5)"
+
+    @pytest.mark.asyncio
+    async def test_get_ticket_by_ref(self, client):
+        """Lookup by reference hits the dedicated ref endpoint."""
+        with patch.object(
+            client, 'request',
+            new=AsyncMock(return_value={"id": "1140", "ref": "TI1046", "track_id": "abc123"}),
+        ) as mock_request:
+            ticket = await client.get_ticket_by_ref("TI1046")
+
+            method, endpoint = mock_request.call_args[0]
+            assert method == "GET"
+            assert endpoint == "tickets/ref/TI1046"
+            assert ticket["track_id"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_search_tickets(self, client):
+        with patch.object(
+            client, 'request',
+            new=AsyncMock(return_value=[{"id": "1140", "ref": "TI1046"}]),
+        ) as mock_request:
+            results = await client.search_tickets(
+                sqlfilters="((t.ref:like:'%TI1046%'))", limit=10
+            )
+
+            assert len(results) == 1
+            method, endpoint = mock_request.call_args[0]
+            params = mock_request.call_args[1]["params"]
+            assert method == "GET"
+            assert endpoint == "tickets"
+            assert params["limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_create_ticket(self, client):
+        with patch.object(client, 'request', new=AsyncMock(return_value={"id": 1141})) as mock_request:
+            ticket_id = await client.create_ticket(
+                subject="Printer broken",
+                message="The office printer does not respond.",
+                socid=79,
+            )
+
+            assert ticket_id == 1141
+            method, endpoint = mock_request.call_args[0]
+            payload = mock_request.call_args[1]["data"]
+            assert method == "POST"
+            assert endpoint == "tickets"
+            assert payload["subject"] == "Printer broken"
+            assert payload["socid"] == 79
+
+    @pytest.mark.asyncio
+    async def test_create_ticket_fk_soc_alias(self, client):
+        """fk_soc is promoted to socid."""
+        with patch.object(client, 'request', new=AsyncMock(return_value={"id": 1142})) as mock_request:
+            await client.create_ticket(subject="X", message="Y", fk_soc=79)
+
+            payload = mock_request.call_args[1]["data"]
+            assert payload["socid"] == 79
+            assert "fk_soc" not in payload
+
+    @pytest.mark.asyncio
+    async def test_create_ticket_requires_subject_and_message(self, client):
+        with patch.object(client, 'request', new=AsyncMock()) as mock_request:
+            with pytest.raises(DolibarrValidationError) as exc:
+                await client.create_ticket(subject="Only subject")
+
+            assert "message" in exc.value.response_data["missing_fields"]
+            mock_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_ticket_message_with_track_id(self, client):
+        """A given track_id is used directly without a lookup."""
+        with patch.object(client, 'request', new=AsyncMock(return_value={"success": True})) as mock_request:
+            with patch.object(client, 'get_ticket_by_ref', new=AsyncMock()) as mock_lookup:
+                await client.add_ticket_message(track_id="abc123", message="Any update?")
+
+                mock_lookup.assert_not_called()
+                method, endpoint = mock_request.call_args[0]
+                payload = mock_request.call_args[1]["data"]
+                assert method == "POST"
+                assert endpoint == "tickets/messages"
+                assert payload["track_id"] == "abc123"
+                assert "ref" not in payload
+
+    @pytest.mark.asyncio
+    async def test_add_ticket_message_resolves_ref(self, client):
+        """A ref is resolved to its track_id before posting."""
+        with patch.object(client, 'request', new=AsyncMock(return_value={"success": True})) as mock_request:
+            with patch.object(
+                client, 'get_ticket_by_ref',
+                new=AsyncMock(return_value={"id": "1140", "track_id": "resolved999"}),
+            ) as mock_lookup:
+                await client.add_ticket_message(ref="TI1046", message="Resolved message")
+
+                mock_lookup.assert_awaited_once_with("TI1046")
+                payload = mock_request.call_args[1]["data"]
+                assert payload["track_id"] == "resolved999"
+                assert "ref" not in payload
+
+    @pytest.mark.asyncio
+    async def test_add_ticket_message_requires_ref_or_track_id(self, client):
+        with patch.object(client, 'request', new=AsyncMock()) as mock_request:
+            with pytest.raises(DolibarrValidationError) as exc:
+                await client.add_ticket_message(message="No target")
+
+            assert "track_id or ref" in exc.value.response_data["missing_fields"]
+            mock_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_ticket_by_id(self, client):
+        with patch.object(client, 'request', new=AsyncMock(return_value={"id": 1140})) as mock_request:
+            await client.update_ticket(ticket_id=1140, fk_statut=8)
+
+            method, endpoint = mock_request.call_args[0]
+            payload = mock_request.call_args[1]["data"]
+            assert method == "PUT"
+            assert endpoint == "tickets/1140"
+            assert payload["fk_statut"] == 8
+
+    @pytest.mark.asyncio
+    async def test_update_ticket_resolves_ref(self, client):
+        """When only a ref is given the internal id is resolved first."""
+        with patch.object(client, 'request', new=AsyncMock(return_value={"id": 1140})) as mock_request:
+            with patch.object(
+                client, 'get_ticket_by_ref',
+                new=AsyncMock(return_value={"id": "1140", "ref": "TI1046"}),
+            ) as mock_lookup:
+                await client.update_ticket(ref="TI1046", fk_statut=4)
+
+                mock_lookup.assert_awaited_once_with("TI1046")
+                method, endpoint = mock_request.call_args[0]
+                assert method == "PUT"
+                assert endpoint == "tickets/1140"
+
+    @pytest.mark.asyncio
+    async def test_update_ticket_requires_id_or_ref(self, client):
+        with patch.object(client, 'request', new=AsyncMock()) as mock_request:
+            with pytest.raises(DolibarrValidationError) as exc:
+                await client.update_ticket(fk_statut=8)
+
+            assert "ticket_id or ref" in exc.value.response_data["missing_fields"]
+            mock_request.assert_not_called()


### PR DESCRIPTION
Implements ticket management support requested in #27.

## New MCP tools

| Tool | Purpose |
|---|---|
| `get_tickets` | List tickets; by default only **open** ones (excludes status 8=closed, 9=cancelled). Optional exact `status` filter and pagination. |
| `get_ticket_by_ref` | Fetch one ticket by its business `ref` (e.g. `TI1046`), including the `messages` array and the `track_id`. |
| `search_tickets` | Search by `ref`, `subject` or `track_id`. |
| `create_ticket` | Create a ticket (requires `subject` + `message`). |
| `add_ticket_message` | Append a message; accepts `ref` (auto-resolved to `track_id`) or `track_id` directly. |
| `update_ticket` | Update a ticket (status, subject, assignment …) by `ref` or numeric `ticket_id`. |

## Implementation notes

- The Dolibarr `status` query parameter is unreliable for tickets, so `get_tickets` filters open tickets via `sqlfilters` on `t.fk_statut` instead.
- `ref`-based convenience: `add_ticket_message` and `update_ticket` accept a human `ref` and resolve it to the internal `track_id` / `id` automatically.
- Input validation via the shared payload helpers (`required_fields`, `required_any_of`, `non_empty_fields`, field aliases).

## Files

- `dolibarr_client.py` — ticket client methods (+132)
- `dolibarr_mcp_server.py` — tool definitions + handlers (+217)
- `tests/test_ticket_operations.py` — test coverage (+197)
- `docs/api-reference.md`, `CHANGELOG.md` — documentation

## Testing

Verified against a live Dolibarr instance:
- `get_tickets()` returns all open tickets, correctly excluding closed/cancelled
- `get_tickets(status=N)` exact status filter
- `get_tickets(page=N)` pagination
- `search_tickets` and `get_ticket_by_ref` return the expected records, including `track_id`

### Note on the page parameter

During live testing, `get_tickets` initially returned an empty list: the Dolibarr `/tickets` endpoint returns an empty page when `page=1` is sent together with `sqlfilters`. Fixed by only sending `page` when explicitly paginating (`page > 1`); real pagination is unaffected.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)