### PR TITLE
fix(projects): get_projects returns empty list because of page=1 param

### DIFF
--- a/src/dolibarr_mcp/dolibarr_client.py
+++ b/src/dolibarr_mcp/dolibarr_client.py
@@ -817,7 +817,9 @@ class DolibarrClient:
     
     async def get_projects(self, limit: int = 100, page: int = 1, status: Optional[int] = None) -> List[Dict[str, Any]]:
         """Get list of projects."""
-        params: Dict[str, Any] = {"limit": limit, "page": page}
+        params: Dict[str, Any] = {"limit": limit}
+        if page and page > 1:
+            params["page"] = page
         if status is not None:
             params["status"] = status
         result = await self.request("GET", "projects", params=params)


### PR DESCRIPTION
## Problem

`get_projects()` returned an empty list (`[]`) even though projects exist.

## Root Cause

The Dolibarr `/projects` endpoint returns an **empty page** when `page=1` is sent as a query parameter. `get_projects` always included `page` (defaulting to `page=1`), so the default call never returned any rows. Unlike the analogous tickets bug, this is **not** tied to `sqlfilters` — it happens for plain `/projects` calls too.

Verified against a live instance:

| Request | Result |
|---|---|
| `limit=500` (no page) | 8 projects |
| `limit=500, page=1` | 0 projects |
| `limit=500, page=1, status=1` | 0 projects |
| `limit=500, status=1` (no page) | 8 projects |

## Fix

Only send the `page` parameter when explicitly paginating (`page > 1`). Real pagination is unaffected — verified `get_projects(page=2, limit=3)` still returns the expected rows.

## Testing

Against a live Dolibarr instance after the fix:
- `get_projects()` → 8 projects ✅ (was 0)
- `get_projects(page=2, limit=3)` → 2 projects ✅

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)